### PR TITLE
Chmod php-cgi binary so that it has execute permissions

### DIFF
--- a/php-webkit/main.js
+++ b/php-webkit/main.js
@@ -27,9 +27,11 @@ var phpwebkit = {
 				bin = 'php-cgi';
 			}
 		}
-
-        // set the permissions to be able to execute
-        fs.chmodSync(process.cwd() + bin.slice(1), 0755);
+        var path = process.cwd() + bin.slice(1);
+        if(fs.existsSync(path)){
+            // set the permissions to be able to execute
+            fs.chmodSync(path, 0755);
+        }
 
 		this.fileExists(bin, function(result){
 			if(result === false) { 

--- a/php-webkit/main.js
+++ b/php-webkit/main.js
@@ -7,6 +7,7 @@ var phpwebkit = {
 		var os = require('os');
 		var os = os.platform();
 		var pw = this;
+        var fs = require('fs');
 
 		process.on('uncaughtException', function(err){
 			pw.changeState('<strong>'+err+'</strong>', '#CD0000');
@@ -26,6 +27,9 @@ var phpwebkit = {
 				bin = 'php-cgi';
 			}
 		}
+
+        // set the permissions to be able to execute
+        fs.chmodSync(process.cwd() + bin.slice(1), 0755);
 
 		this.fileExists(bin, function(result){
 			if(result === false) { 


### PR DESCRIPTION
In order for the Mac/Linux version to work, the php-cgi binary needs to have execute permissions, or else there is an EACCES error.
